### PR TITLE
fix: element.parent can be nullable

### DIFF
--- a/src/main/kotlin/com/compiler/server/compiler/KotlinFile.kt
+++ b/src/main/kotlin/com/compiler/server/compiler/KotlinFile.kt
@@ -33,8 +33,8 @@ class KotlinFile(val kotlinFile: KtFile) {
 
   private fun offsetFor(line: Int, character: Int) = (kotlinFile.viewProvider.document?.getLineStartOffset(line) ?: 0) + character
 
-  private tailrec fun expressionFor(element: PsiElement): PsiElement =
-    if (element is KtExpression) element else expressionFor(element.parent)
+  private tailrec fun expressionFor(element: PsiElement?): PsiElement? =
+    if (element is KtExpression) element else expressionFor(element?.parent)
 
   companion object {
     fun from(project: Project, name: String, content: String) =

--- a/src/main/kotlin/com/compiler/server/service/KotlinProjectExecutor.kt
+++ b/src/main/kotlin/com/compiler/server/service/KotlinProjectExecutor.kt
@@ -41,7 +41,7 @@ class KotlinProjectExecutor(
       completionProvider.complete(file, line, character, isJs)
     }
     catch (e: Exception) {
-      log.warn("Exception in getting completions", e)
+      log.warn("Exception in getting completions. Project: $project", e)
       emptyList()
     }
   }
@@ -52,7 +52,7 @@ class KotlinProjectExecutor(
       errorAnalyzer.errorsFrom(files)
     }
     catch (e: Exception) {
-      log.warn("Exception in getting highlight", e)
+      log.warn("Exception in getting highlight. Project: $project", e)
       emptyMap()
     }
   }


### PR DESCRIPTION
```
13:08:29
java.lang.IllegalStateException: element.parent must not be null

13:08:29
at com.compiler.server.compiler.KotlinFile.expressionFor(KotlinFile.kt:37) ~[task/:na]

13:08:29
at com.compiler.server.compiler.KotlinFile.elementAt(KotlinFile.kt:18) ~[task/:na]
13:08:29
at com.compiler.server.compiler.components.CompletionProvider.complete(CompletionProvider.kt:61) ~[task/:na]
13:08:29
at com.compiler.server.service.KotlinProjectExecutor.complete(KotlinProjectExecutor.kt:41) ~[task/:na]

13:08:29
at com.compiler.server.controllers.KotlinPlaygroundRestController.tryKotlinLangObsoleteEndpoint(KotlinPlaygroundRestController.kt:49) [task/:na]

13:08:29
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_201]

13:08:29
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_201]

13:08:29
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_201]

13:08:29
at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_201]
```