### PR TITLE
Update KotlinFile.kt

### DIFF
--- a/src/main/kotlin/com/compiler/server/compiler/KotlinFile.kt
+++ b/src/main/kotlin/com/compiler/server/compiler/KotlinFile.kt
@@ -34,7 +34,7 @@ class KotlinFile(val kotlinFile: KtFile) {
     (kotlinFile.viewProvider.document?.getLineStartOffset(line) ?: 0) + character
 
   private tailrec fun expressionFor(element: PsiElement?): PsiElement? =
-    if (element is KtExpression) element else expressionFor(element?.parent)
+    if (element is KtExpression?) element else expressionFor(element?.parent)
 
   companion object {
     fun from(project: Project, name: String, content: String) =


### PR DESCRIPTION
Bug fixed:
* Precondition: `null`-argument is provided to `expressionFor`.
* Expected behaviour: null returned
* Actual behaviour: infinite recursion