### PR TITLE
KTL-89 JSON events in the stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ curl -X POST \
   "files": [
     {
       "name": "File.kt",
-      "text": "fun main() {\n    val sinusoid = "sinusoid"\n    val s = sin\n}"
+      "text": "fun main() {\n    val sinusoid = \"sinusoid\"\n    val s = sin\n}"
     }
   ]
 }'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ val kotlinIdeVersion: String by System.getProperties()
 val policy: String by System.getProperties()
 val indexes: String by System.getProperties()
 val indexesJs: String by System.getProperties()
+val executorLogs: String by System.getProperties()
 
 group = "com.compiler.server"
 version = "$kotlinVersion-SNAPSHOT"
@@ -129,6 +130,7 @@ fun generateProperties(prefix: String = "") = """
     indexesJs.file=${prefix + indexesJs}
     libraries.folder.jvm=${prefix + libJVMFolder}
     libraries.folder.js=${prefix + libJSFolder}
+    executor.logs=${executorLogs}
 """.trimIndent()
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.amazonaws.serverless:aws-serverless-java-container-springboot2:1.6")
     implementation("junit:junit:4.12")
+    implementation("net.logstash.logback:logstash-logback-encoder:6.6")
     implementation("org.jetbrains.intellij.deps:trove4j:1.0.20200330")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ systemProp.kotlinIdeVersion=1.5.30-release-412
 systemProp.policy=executor.policy
 systemProp.indexes=indexes.json
 systemProp.indexesJs=indexesJs.json
+systemProp.executorLogs=true

--- a/src/main/kotlin/com/compiler/server/model/ExecutionResult.kt
+++ b/src/main/kotlin/com/compiler/server/model/ExecutionResult.kt
@@ -14,6 +14,19 @@ open class ExecutionResult(
   fun addWarnings(warnings: Map<String, List<ErrorDescriptor>>) {
     errors = warnings
   }
+
+  fun isUnsuccessful() =
+    textWithError() || errors.any { (_, value) -> value.any { it.severity == ProjectSeveriry.ERROR } }
+
+  fun errorsMessages(): List<String> {
+    val compilationErrors: List<String> =
+      errors.flatMap { it.value }.filter { it.severity == ProjectSeveriry.ERROR }.map { it.message }
+
+    return if (textWithError()) compilationErrors + text
+    else compilationErrors
+  }
+
+  private fun textWithError() = text.startsWith("<errStream>")
 }
 
 data class TranslationJSResult(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ indexes.file=indexes.json
 indexesJs.file=indexesJs.json
 libraries.folder.jvm=1.5.30
 libraries.folder.js=1.5.30-js
+executor.logs=true

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="jsonAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>date_time</timestamp>
+            </fieldNames>
+            <timestampPattern>dd/MMM/yyyy:HH:mm:ss XXX</timestampPattern>
+        </encoder>
     </appender>
 
     <root level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="jsonAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="jsonAppender" />
+    </root>
+</configuration>


### PR DESCRIPTION
Hi, @AlexanderPrendota!
YouTrack issue: [KTL-89](https://youtrack.jetbrains.com/issue/KTL-89)

We want to observe compiler-server errors with the ELK stack.
For that, the log's event should be in JSON format and contain some fields of request and response.

So, there is a couple of changes to achieve it:
- Format logs event as JSON (3f0d0ff)
- Log execution errors by KotlinProjectExecutor (360bc98)

For example, now the event with compilation errors look like:
```
{
  "@timestamp": "2021-08-26T18:38:57.875+03:00",
  "@version": "1",
  "message": "Compilation end with errors",
  "logger_name": "com.compiler.server.service.KotlinProjectExecutor",
  "thread_name": "http-nio-8080-exec-8",
  "level": "INFO",
  "level_value": 20000,
  "errors": [
    "No main method found in project.\n"
  ],
  "confType": "JAVA",
  "kotlinVersion": "1.5.21"
}
```