### PR TITLE
chore(logger): add logger for JS translation (1.2.71)

### DIFF
--- a/src/main/kotlin/com/compiler/server/service/KotlinProjectExecutor.kt
+++ b/src/main/kotlin/com/compiler/server/service/KotlinProjectExecutor.kt
@@ -34,7 +34,7 @@ class KotlinProjectExecutor(
 
   fun convertToJs(project: Project): TranslationJSResult {
     val files = getFilesFrom(project).map { it.kotlinFile }
-    return kotlinToJSTranslator.translate(files, project.args.split(" "))
+    return kotlinToJSTranslator.translate(files, project.args.split(" ")).also { logExecutionResult(project, it) }
   }
 
   fun complete(project: Project, line: Int, character: Int): List<Completion> {


### PR DESCRIPTION
I missed logging for JS translation.