### PR TITLE
chore: count exceptions as errors too in the execution log

### DIFF
--- a/src/main/kotlin/com/compiler/server/model/ExecutionResult.kt
+++ b/src/main/kotlin/com/compiler/server/model/ExecutionResult.kt
@@ -15,7 +15,7 @@ open class ExecutionResult(
     errors = warnings
   }
 
-  fun hasErrors() = textWithError() || errors.any { (_, value) -> value.any { it.severity == ProjectSeveriry.ERROR } }
+  fun hasErrors() = textWithError() || exception != null || errors.any { (_, value) -> value.any { it.severity == ProjectSeveriry.ERROR } }
 
   private fun textWithError() = text.startsWith(ERROR_STREAM_START)
 }


### PR DESCRIPTION
When an exception occurs while executing a user's code, the HasError field has a mistakenly false value.
The PR fixes this flaw.