### PR TITLE
1.3.70 Migrate -Xuse-experimental -> -Xopt-in in compiler args

### DIFF
--- a/src/main/kotlin/com/compiler/server/compiler/components/KotlinEnvironment.kt
+++ b/src/main/kotlin/com/compiler/server/compiler/components/KotlinEnvironment.kt
@@ -45,12 +45,12 @@ class KotlinEnvironment(
      * [org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments] for list of possible flags
      */
     private val additionalCompilerArguments: List<String> = listOf(
-      "-Xuse-experimental=kotlin.ExperimentalStdlibApi",
-      "-Xuse-experimental=kotlin.time.ExperimentalTime",
-      "-Xuse-experimental=kotlin.Experimental",
-      "-Xuse-experimental=kotlin.ExperimentalUnsignedTypes",
-      "-Xuse-experimental=kotlin.contracts.ExperimentalContracts",
-      "-Xuse-experimental=kotlin.experimental.ExperimentalTypeInference",
+      "-Xopt-in=kotlin.ExperimentalStdlibApi",
+      "-Xopt-in=kotlin.time.ExperimentalTime",
+      "-Xopt-in=kotlin.RequiresOptIn",
+      "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
+      "-Xopt-in=kotlin.contracts.ExperimentalContracts",
+      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
       "-XXLanguage:+InlineClasses"
     )
 


### PR DESCRIPTION
The compiler argument -Xuse-experimental has been renamed to -Xopt-in in 1.3.70.
[More details](https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/).
I'm going to spread this fix to other branches.