### PR TITLE
1.5.31 Update compiler arguments

### DIFF
--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -46,7 +46,7 @@ class KotlinEnvironment(
       "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
       "-Xopt-in=kotlin.contracts.ExperimentalContracts",
       "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
-      "-XXLanguage:+InlineClasses"
+      "-Xinline-classes"
     )
   }
 

--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -40,12 +40,12 @@ class KotlinEnvironment(
      * [org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments] for list of possible flags
      */
     private val additionalCompilerArguments: List<String> = listOf(
-      "-Xuse-experimental=kotlin.ExperimentalStdlibApi",
-      "-Xuse-experimental=kotlin.time.ExperimentalTime",
-      "-Xuse-experimental=kotlin.Experimental",
-      "-Xuse-experimental=kotlin.ExperimentalUnsignedTypes",
-      "-Xuse-experimental=kotlin.contracts.ExperimentalContracts",
-      "-Xuse-experimental=kotlin.experimental.ExperimentalTypeInference",
+      "-Xopt-in=kotlin.ExperimentalStdlibApi",
+      "-Xopt-in=kotlin.time.ExperimentalTime",
+      "-Xopt-in=kotlin.RequiresOptIn",
+      "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
+      "-Xopt-in=kotlin.contracts.ExperimentalContracts",
+      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
       "-XXLanguage:+InlineClasses"
     )
   }

--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -45,8 +45,7 @@ class KotlinEnvironment(
       "-Xopt-in=kotlin.RequiresOptIn",
       "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
       "-Xopt-in=kotlin.contracts.ExperimentalContracts",
-      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
-      "-Xinline-classes"
+      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference"
     )
   }
 

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
@@ -247,19 +247,4 @@ class KotlinFeatureSince140 : BaseExecutorTest() {
       contains = "42"
     )
   }
-
-  @Test
-  fun `Inline classes are in Beta`() {
-    run(
-      code = """
-          inline class Hours(val value: Int)
-
-          fun main(args: Array<String>) {
-          	val hours = Hours(12)
-              println(hours.value)
-          }
-        """.trimIndent(),
-      contains = "12"
-    )
-  }
 }

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
@@ -247,4 +247,19 @@ class KotlinFeatureSince140 : BaseExecutorTest() {
       contains = "42"
     )
   }
+
+  @Test
+  fun `Inline classes are in Beta`() {
+    run(
+      code = """
+          inline class Hours(val value: Int)
+
+          fun main(args: Array<String>) {
+          	val hours = Hours(12)
+              println(hours.value)
+          }
+        """.trimIndent(),
+      contains = "12"
+    )
+  }
 }

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince150.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince150.kt
@@ -208,4 +208,20 @@ class KotlinFeatureSince150 : BaseExecutorTest() {
     )
   }
 
+
+  @Test
+  fun `Inline classes are Stable`() {
+    run(
+      code = """
+          @JvmInline
+          value class Hours(val value: Int)
+
+          fun main(args: Array<String>) {
+          	val hours = Hours(12)
+              println(hours.value)
+          }
+        """.trimIndent(),
+      contains = "12"
+    )
+  }
 }


### PR DESCRIPTION
There are a few changes:
- `-Xuse-experimental` argument was changed #529.
- chery-pick a test for inline classes from #530.
- update the inline classes' test and remove experimental attribute due to inline classes are a stable feature.