### PR TITLE
1.7.20-Beta Update compiler arguments 

### DIFF
--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -46,7 +46,8 @@ class KotlinEnvironment(
       "-opt-in=kotlin.RequiresOptIn",
       "-opt-in=kotlin.ExperimentalUnsignedTypes",
       "-opt-in=kotlin.contracts.ExperimentalContracts",
-      "-opt-in=kotlin.experimental.ExperimentalTypeInference"
+      "-opt-in=kotlin.experimental.ExperimentalTypeInference",
+      "-Xcontext-receivers"
     )
   }
 

--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -47,7 +47,8 @@ class KotlinEnvironment(
       "-opt-in=kotlin.ExperimentalUnsignedTypes",
       "-opt-in=kotlin.contracts.ExperimentalContracts",
       "-opt-in=kotlin.experimental.ExperimentalTypeInference",
-      "-Xcontext-receivers"
+      "-Xcontext-receivers",
+      "-XXLanguage:+RangeUntilOperator"
     )
   }
 

--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -46,8 +46,7 @@ class KotlinEnvironment(
       "-Xopt-in=kotlin.RequiresOptIn",
       "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
       "-Xopt-in=kotlin.contracts.ExperimentalContracts",
-      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
-      "-Xinline-classes"
+      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference"
     )
   }
 

--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -41,12 +41,12 @@ class KotlinEnvironment(
      * [org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments] for list of possible flags
      */
     private val additionalCompilerArguments: List<String> = listOf(
-      "-Xuse-experimental=kotlin.ExperimentalStdlibApi",
-      "-Xuse-experimental=kotlin.time.ExperimentalTime",
-      "-Xuse-experimental=kotlin.Experimental",
-      "-Xuse-experimental=kotlin.ExperimentalUnsignedTypes",
-      "-Xuse-experimental=kotlin.contracts.ExperimentalContracts",
-      "-Xuse-experimental=kotlin.experimental.ExperimentalTypeInference",
+      "-Xopt-in=kotlin.ExperimentalStdlibApi",
+      "-Xopt-in=kotlin.time.ExperimentalTime",
+      "-Xopt-in=kotlin.RequiresOptIn",
+      "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
+      "-Xopt-in=kotlin.contracts.ExperimentalContracts",
+      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
       "-XXLanguage:+InlineClasses"
     )
   }

--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -41,12 +41,12 @@ class KotlinEnvironment(
      * [org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments] for list of possible flags
      */
     private val additionalCompilerArguments: List<String> = listOf(
-      "-Xopt-in=kotlin.ExperimentalStdlibApi",
-      "-Xopt-in=kotlin.time.ExperimentalTime",
-      "-Xopt-in=kotlin.RequiresOptIn",
-      "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
-      "-Xopt-in=kotlin.contracts.ExperimentalContracts",
-      "-Xopt-in=kotlin.experimental.ExperimentalTypeInference"
+      "-opt-in=kotlin.ExperimentalStdlibApi",
+      "-opt-in=kotlin.time.ExperimentalTime",
+      "-opt-in=kotlin.RequiresOptIn",
+      "-opt-in=kotlin.ExperimentalUnsignedTypes",
+      "-opt-in=kotlin.contracts.ExperimentalContracts",
+      "-opt-in=kotlin.experimental.ExperimentalTypeInference"
     )
   }
 

--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -47,7 +47,7 @@ class KotlinEnvironment(
       "-Xopt-in=kotlin.ExperimentalUnsignedTypes",
       "-Xopt-in=kotlin.contracts.ExperimentalContracts",
       "-Xopt-in=kotlin.experimental.ExperimentalTypeInference",
-      "-XXLanguage:+InlineClasses"
+      "-Xinline-classes"
     )
   }
 

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
@@ -247,19 +247,4 @@ class KotlinFeatureSince140 : BaseExecutorTest() {
       contains = "42"
     )
   }
-
-  @Test
-  fun `Inline classes are in Beta`() {
-    run(
-      code = """
-          inline class Hours(val value: Int)
-
-          fun main(args: Array<String>) {
-          	val hours = Hours(12)
-              println(hours.value)
-          }
-        """.trimIndent(),
-      contains = "12"
-    )
-  }
 }

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince140.kt
@@ -247,4 +247,19 @@ class KotlinFeatureSince140 : BaseExecutorTest() {
       contains = "42"
     )
   }
+
+  @Test
+  fun `Inline classes are in Beta`() {
+    run(
+      code = """
+          inline class Hours(val value: Int)
+
+          fun main(args: Array<String>) {
+          	val hours = Hours(12)
+              println(hours.value)
+          }
+        """.trimIndent(),
+      contains = "12"
+    )
+  }
 }

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince150.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince150.kt
@@ -208,4 +208,20 @@ class KotlinFeatureSince150 : BaseExecutorTest() {
     )
   }
 
+
+  @Test
+  fun `Inline classes are Stable`() {
+    run(
+      code = """
+          @JvmInline
+          value class Hours(val value: Int)
+
+          fun main(args: Array<String>) {
+          	val hours = Hours(12)
+              println(hours.value)
+          }
+        """.trimIndent(),
+      contains = "12"
+    )
+  }
 }

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince160.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince160.kt
@@ -71,4 +71,35 @@ class KotlinFeatureSince160 : BaseExecutorTest() {
       contains = "<outStream>[1, 2, 3, 5]\n</outStream>"
     )
   }
+
+  @Test
+  fun `Prototype of context receivers`() {
+    run(
+      code = """
+        class Logger {
+          fun info(message: String) = println(message)
+        }
+
+        interface LoggingContext {
+          val log: Logger
+        }
+
+        context(LoggingContext)
+        fun executeTask() {
+          log.info("Complete")
+        }
+
+        fun main() {
+          val loggingContext = object: LoggingContext {
+            override val log = Logger()
+          }
+            
+          with(loggingContext) {
+            executeTask()
+          }
+        }
+      """.trimIndent(),
+      contains = "Complete"
+    )
+  }
 }

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince170.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince170.kt
@@ -75,4 +75,22 @@ class KotlinFeatureSince170 : BaseExecutorTest() {
             contains = "Date of birth: 2022-04-27"
         )
     }
+    @Test
+    fun `New operator for defining the open-ended range`() {
+        run(
+            code = """
+            fun main() {
+                val number = 0.25
+    
+                when (number) {
+                    in 0.0..<0.25 -> println("first quarter")
+                    in 0.25..<0.5 -> println("second quarter")
+                    in 0.5..<0.75 -> println("third quarter")
+                    in 0.75..1.0 ->  println("last quarter")
+            }
+          }
+        """.trimIndent(),
+        contains = "second quarter"
+        )
+    }
 }


### PR DESCRIPTION
There are commits from #533 and one more for supporting the `..<` operator for [creating open-ended ranges﻿](https://kotlinlang.org/docs/whatsnew-eap.html#preview-of-the-operator-for-creating-open-ended-ranges).